### PR TITLE
disable restrictions for date/time items

### DIFF
--- a/src/app/lib/widgets/restrictions/restrictions.component.ts
+++ b/src/app/lib/widgets/restrictions/restrictions.component.ts
@@ -59,9 +59,9 @@ export class RestrictionsComponent extends TableComponent implements OnInit {
   static typeToOptions = {
     decimal: RestrictionsComponent.numberOptions,
     integer: RestrictionsComponent.numberOptions,
-    date: RestrictionsComponent.numberOptions,
-    dateTime: RestrictionsComponent.numberOptions,
-    time: RestrictionsComponent.numberOptions,
+    //date: RestrictionsComponent.numberOptions,
+    //dateTime: RestrictionsComponent.numberOptions,
+    //time: RestrictionsComponent.numberOptions,
     string: RestrictionsComponent.stringOptions,
     text: RestrictionsComponent.stringOptions,
     attachment: RestrictionsComponent.attachOptions


### PR DESCRIPTION
The restriction function does not support date, dateTime and time item, yet. Those types should be removed from typeToOptions, otherwise it will generate a bug when changing the type of an item that has a restriction (a decimal item with maxValue restriction for example) to a date/dateTime or time type (we will have a broken extension having only the restriction url in the extension of the changed item )

Steps to reproduce the bug:
1. create a decimal item having 'Maximum Value' and 'Minimum Value' as restrictions:
![image](https://github.com/ghaliouss/formbuilder-lhcforms/assets/14861910/ba11e983-349b-4f55-8b46-c05797e8cb12)
2. change the type of the item to 'Date'
![image](https://github.com/ghaliouss/formbuilder-lhcforms/assets/14861910/cda54613-f837-4558-b62d-3a56a9fd7719)
3. Verify the json from the preview: the two extensions still present in the model (but broken), we should not have those extension for date/time items
![image](https://github.com/ghaliouss/formbuilder-lhcforms/assets/14861910/f67db637-81f2-402c-9cc0-c6a123796df7)


